### PR TITLE
Remove the Customer IP from the info log message

### DIFF
--- a/middleware/request_logs.rb
+++ b/middleware/request_logs.rb
@@ -10,11 +10,10 @@ module CloudFoundry
         request = ActionDispatch::Request.new(env)
 
         @logger.info(
-          sprintf('Started %<method>s "%<path>s" for user: %<user>s, ip: %<ip>s with vcap-request-id: %<request_id>s at %<at>s',
+          sprintf('Started %<method>s "%<path>s" for user: %<user>s with vcap-request-id: %<request_id>s at %<at>s',
             method: request.request_method,
             path: request.filtered_path,
             user: env['cf.user_guid'],
-            ip: request.ip,
             request_id: env['cf.request_id'],
             at: Time.now.utc)
         )


### PR DESCRIPTION
Thanks for contributing to cloud_controller_ng. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Remove the customer IPs from the log level info messages

* An explanation of the use cases your change solves
We can not have the IP of customers in the log messages as it violates our corporate rules

* Links to any other associated PRs

* [x] I have reviewed the [contributing guide](https://github.com/cloudfoundry/cloud_controller_ng/blob/master/CONTRIBUTING.md)

* [x] I have viewed, signed, and submitted the Contributor License Agreement

* [x] I have made this pull request to the `master` branch

* [x] I have run all the unit tests using `bundle exec rake`

* [x] I have run [CF Acceptance Tests](https://github.com/cloudfoundry/cloud_controller_ng#cf-acceptance-tests-cats)
